### PR TITLE
LM-1056 : SAML response throws Exception on first response after startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ vim /home/ec2-user/laa-saml-mock/mujina-sp/laa-saml-mock-sp-application.yml
 sp:
   base_url: http://${EC2_PUBLIC_HOST}:9090
   entity_id: http://mock-sp
+  idp_metadata_url: http://${EC2_PUBLIC_HOST}:8080/metadata
   single_sign_on_service_location: http://${EC2_PUBLIC_HOST}:8080/SingleSignOnService
   acs_location_path: /saml/SSO
 ```

--- a/aws-ec2/readme.md
+++ b/aws-ec2/readme.md
@@ -99,6 +99,7 @@ vim /home/ec2-user/laa-saml-mock/mujina-sp/laa-saml-mock-sp-application.yml
 sp:
   base_url: http://${EC2_PUBLIC_HOST}:9090
   entity_id: http://mock-sp
+  idp_metadata_url: http://${EC2_PUBLIC_HOST}:8080/metadata
   single_sign_on_service_location: http://${EC2_PUBLIC_HOST}:8080/SingleSignOnService
   acs_location_path: /saml/SSO
 ```
@@ -114,6 +115,9 @@ vim ~/start-laa-saml-mock-services.sh
 export EC2_PUBLIC_HOST=`curl http://169.254.169.254/latest/meta-data/public-ipv4`;
 
 cd /home/ec2-user/laa-saml-mock/mujina-idp/target; sudo -u ec2-user nohup java -DEC2_PUBLIC_HOST=${EC2_PUBLIC_HOST} -jar laa-saml-mock-idp-1.0.0.jar --spring.config.location=/home/ec2-user/laa-saml-mock/mujina-idp/laa-saml-mock-idp-application.yml &
+
+echo "Sleeping for 15 seconds to allow the IdP to start up..."
+sleep 20s
 
 cd /home/ec2-user/laa-saml-mock/mujina-sp/target; sudo -u ec2-user nohup java -DEC2_PUBLIC_HOST=${EC2_PUBLIC_HOST} -jar laa-saml-mock-sp-1.0.0.jar --spring.config.location=/home/ec2-user/laa-saml-mock/mujina-sp/laa-saml-mock-sp-application.yml &
 ```

--- a/mujina-idp/src/main/java/mujina/idp/MetadataController.java
+++ b/mujina-idp/src/main/java/mujina/idp/MetadataController.java
@@ -77,10 +77,9 @@ public class MetadataController {
 
     idpssoDescriptor.addSupportedProtocol(SAMLConstants.SAML20P_NS);
 
-    String localPort = environment.getProperty("local.server.port");
-    
+    String idpBaseUrl = environment.getProperty("idp.base_url");
     SingleSignOnService singleSignOnService = buildSAMLObject(SingleSignOnService.class, SingleSignOnService.DEFAULT_ELEMENT_NAME);
-    singleSignOnService.setLocation("http://localhost:" + localPort + "/SingleSignOnService");
+    singleSignOnService.setLocation(idpBaseUrl + "/SingleSignOnService");
     singleSignOnService.setBinding(SAMLConstants.SAML2_REDIRECT_BINDING_URI);
 
     idpssoDescriptor.getSingleSignOnServices().add(singleSignOnService);

--- a/mujina-idp/src/test/java/mujina/idp/MetadataControllerTest.java
+++ b/mujina-idp/src/test/java/mujina/idp/MetadataControllerTest.java
@@ -22,7 +22,7 @@ public class MetadataControllerTest extends AbstractIntegrationTest {
       .statusCode(SC_OK)
       .body(
         "EntityDescriptor.IDPSSODescriptor.SingleSignOnService.@Location",
-        equalTo("http://localhost:" + serverPort + "/SingleSignOnService"));
+        equalTo("http://localhost:8080/SingleSignOnService"));
   }
 
 }


### PR DESCRIPTION
Updated instructions in the main readme files to specify the IdP metadata
URL in the SP spring configuration file when deploying the SP service
outside of localhost.

Updated the idp MetadataController to support deployment outside of
localhost.