### PR TITLE
LM-969: SAML - Update IDP to use SHA-256

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ This API is available on both the IDP and the SP.
 ```bash
 curl -v -H "Accept: application/json" \
         -H "Content-type: application/json" \
-        -X PUT -d "http://www.w3.org/2000/09/xmldsig#rsa-sha1" \
+        -X PUT -d "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256" \
         http://localhost:9090/api/signatureAlgorithm
 ```        
 

--- a/aws-ec2/readme.md
+++ b/aws-ec2/readme.md
@@ -13,18 +13,18 @@ Create an EC2 instance and log in to via ssh and run the following steps:
 10. [Reboot your EC2 instance](#10-reboot-your-ec2-instance)
 
 ### 1. Update your OS
-```
+```bash
 sudo yum update -y
 ```
 
 ### 2. Install java 8
-```
+```bash
 sudo yum remove -y java-1.7.0-openjdk
 sudo yum install -y java-1.8.0-openjdk-devel.x86_64
 ```
 
 ### 3. Install & configure maven
-```
+```bash
 cd ~
 wget http://apache.mirrors.nublue.co.uk/maven/maven-3/3.5.2/binaries/apache-maven-3.5.2-bin.tar.gz
 tar -xvf apache-maven-3.5.2-bin.tar.gz
@@ -32,12 +32,12 @@ rm apache-maven-3.5.2-bin.tar.gz
 ```
 
 Add Maven to the environment
-```
+```bash
 vim ~/.bash_profile
 ```
 
 ... and insert this text:
-```
+```bash
 # .bash_profile
 
 # Get the aliases and functions
@@ -56,28 +56,28 @@ export PATH=${M2_HOME}/bin:${PATH}
 ```
 
 ### 4. Install git
-```
+```bash
 sudo yum install -y git
 ```
 
 ### 5. Clone the laa-sam-mock gihub repo
-```
+```bash
 git clone https://github.com/ministryofjustice/laa-saml-mock
 ```
 
 ### 6. Run mvn install
-```
+```bash
 cd laa-saml-mock
 mvn clean install
 ```
 
 ### 7. Configure spring boot application.yml files
-```
+```bash
 vim /home/ec2-user/laa-saml-mock/mujina-idp/laa-saml-mock-idp-application.yml
 ```
 
 ... and insert this text:
-```
+```bash
 idp:
   base_url: http://${EC2_PUBLIC_HOST}:8080
 
@@ -90,12 +90,12 @@ samlUserStore:
         attribute 2: test attribute 2 value
 ```
 
-```
+```bash
 vim /home/ec2-user/laa-saml-mock/mujina-sp/laa-saml-mock-sp-application.yml
 ```
 
 ... and insert this text:
-```
+```bash
 sp:
   base_url: http://${EC2_PUBLIC_HOST}:9090
   entity_id: http://mock-sp
@@ -105,12 +105,12 @@ sp:
 ```
 
 ### 8. Create startup script for spring boot apps
-```
+```bash
 vim ~/start-laa-saml-mock-services.sh
 ```
 
 ... and insert this text:
-```
+```bash
 #!/bin/bash
 export EC2_PUBLIC_HOST=`curl http://169.254.169.254/latest/meta-data/public-ipv4`;
 
@@ -123,12 +123,12 @@ cd /home/ec2-user/laa-saml-mock/mujina-sp/target; sudo -u ec2-user nohup java -D
 ```
 
 ### 9. Create a service to start with the OS
-```
+```bash
 sudo vim /etc/rc.local
 ```
 
 ... and insert this text:
-```
+```bash
 #!/bin/sh
 #
 # This script will be executed *after* all the other init scripts.

--- a/mujina-idp/src/test/java/mujina/idp/SsoControllerTest.java
+++ b/mujina-idp/src/test/java/mujina/idp/SsoControllerTest.java
@@ -26,7 +26,7 @@ import static org.junit.Assert.assertTrue;
 public class SsoControllerTest extends AbstractIntegrationTest {
 
   private List<String[]> params = Arrays.asList(
-    new String[]{"SigAlg", "http://www.w3.org/2000/09/xmldsig#rsa-sha1"},
+    new String[]{"SigAlg", "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"},
     new String[]{"SAMLRequest", "fZFRb4IwFIX/StN3oIIb2AjGzZiZuEgE97C3WitgoGW9xfjzVxU3lyU+3vbce8797nhyamp0FBoqJWM8cAlGQnK1q2QR400+dyI8ScbAmtpv6bQzpVyLr06AQbZRAr3+xLjTkioGFVDJGgHUcJpN35fUdwlttTKKqxqjKYDQxlq9KgldI3Qm9LHiYrNexrg0pqWeVyvO6lKBoSMyIt7ZwMuyFUYz61pJZi5J/4kjEhEvs7FrkVWFXMl+NEZzpbm4RI/xntVgnxazGLMBI8WwfC59vtvZYnsQfsAPBSdhET5ZDaQMoDqK3y6ATiwkGCZNjH0yCB0SOP4wHwR0GNBg5IZB9IlR2u/7Uskrx0dwtlcR0Lc8T510leUYfdzuYQW4p08v7voe++PB7MYaJ2dYYGk13cECdKF1f7i50Ok9V1KcjCvrsXfvlfTl38Mn3w=="},
     new String[]{"Signature", "WWDMxCvr5erxB7H4U6BeI5e/l+EtQQUNPixjMLpfGHekfrQ86u7YEoJH8ZgN2bJG4qoWld6fjuh10j8qehp62Qdktxh81iZUySKkt8xGaWEuWMYzZDPdNsucn8HhSzcp0jyeT5ZihShMFO0Dv/KSCBpAt7WKrrZUrATF6cYoz7HsW3hJLh0lLP+Kr6MA6SrtrCxhaYbKhcZ+3wNHoOYQZhbqxIOvfuihRVnCxm8541gmjtHxj3x/qtQRqswOF7k24wUj6/H5Klj/A1/sZh1MZ5jDHfw795YIH3LqpFPzhWl5XEJ+K84vp0RRWaTUOb1hUPlLLWH8tH0Kd4RhaOcNpQ=="}
   );

--- a/mujina-sp/src/main/resources/metadata/mujina.local.idp.metadata.xml
+++ b/mujina-sp/src/main/resources/metadata/mujina.local.idp.metadata.xml
@@ -4,13 +4,13 @@
   <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
     <ds:SignedInfo>
       <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
-      <ds:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+      <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
       <ds:Reference URI="#6ceb7b22-a038-4d51-a1b0-a4f087814e79">
         <ds:Transforms>
           <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
           <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
         </ds:Transforms>
-        <ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+        <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
         <ds:DigestValue/>
       </ds:Reference>
     </ds:SignedInfo>

--- a/mujina-sp/src/test/resources/saml_response.xml
+++ b/mujina-sp/src/test/resources/saml_response.xml
@@ -22,7 +22,7 @@
               <ec:InclusiveNamespaces xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#" PrefixList="xs"/>
             </ds:Transform>
           </ds:Transforms>
-          <ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+          <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
           <ds:DigestValue>fffd7DnCfmYh878THSo8c+8zbdU=</ds:DigestValue>
         </ds:Reference>
       </ds:SignedInfo>

--- a/onelogin/onelogin.saml.properties
+++ b/onelogin/onelogin.saml.properties
@@ -36,10 +36,10 @@ onelogin.saml2.security.want_nameid_encrypted=false
 onelogin.saml2.security.requested_authncontext=urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport
 onelogin.saml2.security.onelogin.saml2.security.requested_authncontextcomparison = exact
 onelogin.saml2.security.want_xml_validation = true
-onelogin.saml2.security.signature_algorithm=http://www.w3.org/2000/09/xmldsig#rsa-sha1
+onelogin.saml2.security.signature_algorithm=http://www.w3.org/2001/04/xmldsig-more#rsa-sha256
 
 ###
-# Service Provider contacts
+# Service Provider Organisation & Contacts
 onelogin.saml2.organization.name = ${saml.sp.org.name}
 onelogin.saml2.organization.displayname = ${saml.sp.org.displayname}
 onelogin.saml2.organization.url = ${saml.sp.org.url}


### PR DESCRIPTION
Update to all references of SHA1 and replacing with SHA256.
Update to the onelogin properties file to specify a requirement for the SHA256 security algorithm in SAML requests.