### PR TITLE
LM-1098: SAML - CI Pipeline for Mock IdP - Create Dockerfile

### DIFF
--- a/mujina-idp/Dockerfile
+++ b/mujina-idp/Dockerfile
@@ -1,0 +1,8 @@
+FROM openjdk:8-jdk-alpine
+ENV SERVICE_HOST localhost
+
+VOLUME /tmp
+ADD target/laa-saml-mock-idp-1.0.0.jar app.jar
+COPY docker-idp-application.yml config/idp-application.yml
+
+ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom", "-jar","app.jar", "--spring.config.location=config/idp-application.yml", "-DSERVICE_HOST=${SERVICE_HOST}"]

--- a/mujina-idp/docker-idp-application.yml
+++ b/mujina-idp/docker-idp-application.yml
@@ -1,0 +1,10 @@
+idp:
+  base_url: http://${SERVICE_HOST}:8080
+
+samlUserStore:
+  samlUsers:
+    - username: test-user
+      password: test password
+      samlAttributes:
+        attribute 1: test attribute 1 value
+        attribute 2: test attribute 2 value

--- a/mujina-idp/readme.md
+++ b/mujina-idp/readme.md
@@ -1,0 +1,42 @@
+# Build the mock IdP docker image
+
+## Prerequisites
+Before building the Docker image, the Spring Boot application artifact must exist in the **target** directory
+
+> e.g. mujina-idp/target/laa-saml-mock-idp-1.0.0.jar
+
+_The best practice is to run a maven install on the pom.xml in the laa-saml-mock __root__ directory, and then build the docker image._
+```bash
+cd laa-saml-mock
+mvn clean install
+cd mujina-idp
+```
+
+----
+
+```bash
+docker build . -t laa-saml-mock-idp
+```
+
+# Run the mock IdP docker container
+```bash
+docker container run -p 8080:8080 laa-saml-mock-idp
+```
+
+# Run the mock IdP docker container specifying a custom host
+You can use the SERVICE_HOST environment variable to run the mock IdP somewhere other than localhost
+```bash
+docker container run -p 8080:8080 -e SERVICE_HOST=10.98.221.157 laa-saml-mock-idp
+```
+
+# Specify an override spring configuration file
+It is possible to mount a Docker volume to the /config directory and
+provide a file containing a complete override of the spring boot application configuration
+- e.g. config/idp-application.yml
+
+The contents of the file must have the __idp.base_url__ property set to the following value in order for the
+SAML IdP application to work correctly
+```yml
+idp:
+  base_url: http://${SERVICE_HOST}:8080
+```


### PR DESCRIPTION
Create a Dockerfile which uses a docker-specific spring boot application configuration file to support deployments outside of localhost via the SERVICE_HOST environment variable (default SERVICE_HOST=localhost).

It is possible to mount a Docker volume to the /config
directory and provide a file containing a complete override of
 the spring boot application configuration
- e.g. config/idp-application.yml