### PR TITLE
LM-564: Create SAML Identity Provider service for CI usage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,10 +54,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>pl.project13.maven</groupId>
-        <artifactId>git-commit-id-plugin</artifactId>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
         <version>1.4</version>


### PR DESCRIPTION
Removed pl.project13.maven:git-commit-id-plugin which depends on a clone
of the full git repository in order to create a git.properties file.

AWS CodePipeline/CodeBuild performs a shallow clone of the specified
branch, adds it to an S3 bucket, and discards the .git directory
which is required by the git-commit-id-plugin.