### PR TITLE
LM-564: Create SAML Identity Provider service for CI usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ vim /home/ec2-user/laa-saml-mock/mujina-idp/laa-saml-mock-idp-application.yml
 ```
 ```
 idp:
-  base_url: http://${SERVICE_HOST}:8080
+  base_url: http://${IDP_SERVICE_HOST}:8080
 
 samlUserStore:
   samlUsers:
@@ -131,9 +131,9 @@ samlUserStore:
 ##### Start IdP app
 ```
 #!/bin/bash
-export SERVICE_HOST=`curl http://169.254.169.254/latest/meta-data/public-ipv4`;
+export IDP_SERVICE_HOST=`curl http://169.254.169.254/latest/meta-data/public-ipv4`;
 
-cd /home/ec2-user/laa-saml-mock/mujina-idp/target; sudo -u ec2-user nohup java -DSERVICE_HOST=${SERVICE_HOST} -jar laa-saml-mock-idp-1.0.0.jar --spring.config.location=/home/ec2-user/laa-saml-mock/mujina-idp/laa-saml-mock-idp-application.yml &
+cd /home/ec2-user/laa-saml-mock/mujina-idp/target; sudo -u ec2-user nohup java -DIDP_SERVICE_HOST=${IDP_SERVICE_HOST} -jar laa-saml-mock-idp-1.0.0.jar --spring.config.location=/home/ec2-user/laa-saml-mock/mujina-idp/laa-saml-mock-idp-application.yml &
 ```
 
 ##### Tail the log file
@@ -148,19 +148,20 @@ vim /home/ec2-user/laa-saml-mock/mujina-sp/laa-saml-mock-sp-application.yml
 ```
 ```
 sp:
-  base_url: http://${SERVICE_HOST}:9090
+  base_url: http://${SP_SERVICE_HOST}:9090
   entity_id: http://mock-sp
-  idp_metadata_url: http://${SERVICE_HOST}:8080/metadata
-  single_sign_on_service_location: http://${SERVICE_HOST}:8080/SingleSignOnService
+  idp_metadata_url: http://${IDP_SERVICE_HOST}:8080/metadata
+  single_sign_on_service_location: http://${IDP_SERVICE_HOST}:8080/SingleSignOnService
   acs_location_path: /saml/SSO
 ```
 
 ##### Start SP app
 ```
 #!/bin/bash
-export SERVICE_HOST=`curl http://169.254.169.254/latest/meta-data/public-ipv4`;
+export IDP_SERVICE_HOST=`curl http://169.254.169.254/latest/meta-data/public-ipv4`;
+export SP_SERVICE_HOST=`curl http://169.254.169.254/latest/meta-data/public-ipv4`;
 
-cd /home/ec2-user/laa-saml-mock/mujina-sp/target; sudo -u ec2-user nohup java -DSERVICE_HOST=${SERVICE_HOST} -jar laa-saml-mock-sp-1.0.0.jar --spring.config.location=/home/ec2-user/laa-saml-mock/mujina-sp/laa-saml-mock-sp-application.yml &
+cd /home/ec2-user/laa-saml-mock/mujina-sp/target; sudo -u ec2-user nohup java -DIDP_SERVICE_HOST=${IDP_SERVICE_HOST} -DSP_SERVICE_HOST=${SP_SERVICE_HOST} -jar laa-saml-mock-sp-1.0.0.jar --spring.config.location=/home/ec2-user/laa-saml-mock/mujina-sp/laa-saml-mock-sp-application.yml &
 ```
 
 ##### Tail the log file

--- a/aws-ec2/readme.md
+++ b/aws-ec2/readme.md
@@ -79,7 +79,7 @@ vim /home/ec2-user/laa-saml-mock/mujina-idp/laa-saml-mock-idp-application.yml
 ... and insert this text:
 ```bash
 idp:
-  base_url: http://${SERVICE_HOST}:8080
+  base_url: http://${IDP_SERVICE_HOST}:8080
 
 samlUserStore:
   samlUsers:
@@ -97,10 +97,10 @@ vim /home/ec2-user/laa-saml-mock/mujina-sp/laa-saml-mock-sp-application.yml
 ... and insert this text:
 ```bash
 sp:
-  base_url: http://${SERVICE_HOST}:9090
+  base_url: http://${SP_SERVICE_HOST}:9090
   entity_id: http://mock-sp
-  idp_metadata_url: http://${SERVICE_HOST}:8080/metadata
-  single_sign_on_service_location: http://${SERVICE_HOST}:8080/SingleSignOnService
+  idp_metadata_url: http://${IDP_SERVICE_HOST}:8080/metadata
+  single_sign_on_service_location: http://${IDP_SERVICE_HOST}:8080/SingleSignOnService
   acs_location_path: /saml/SSO
 ```
 
@@ -112,14 +112,15 @@ vim ~/start-laa-saml-mock-services.sh
 ... and insert this text:
 ```bash
 #!/bin/bash
-export SERVICE_HOST=`curl http://169.254.169.254/latest/meta-data/public-ipv4`;
+export IDP_SERVICE_HOST=`curl http://169.254.169.254/latest/meta-data/public-ipv4`;
+export SP_SERVICE_HOST=`curl http://169.254.169.254/latest/meta-data/public-ipv4`;
 
-cd /home/ec2-user/laa-saml-mock/mujina-idp/target; sudo -u ec2-user nohup java -DSERVICE_HOST=${SERVICE_HOST} -jar laa-saml-mock-idp-1.0.0.jar --spring.config.location=/home/ec2-user/laa-saml-mock/mujina-idp/laa-saml-mock-idp-application.yml &
+cd /home/ec2-user/laa-saml-mock/mujina-idp/target; sudo -u ec2-user nohup java -DIDP_SERVICE_HOST=${IDP_SERVICE_HOST} -jar laa-saml-mock-idp-1.0.0.jar --spring.config.location=/home/ec2-user/laa-saml-mock/mujina-idp/laa-saml-mock-idp-application.yml &
 
 echo "Sleeping for 15 seconds to allow the IdP to start up..."
 sleep 20s
 
-cd /home/ec2-user/laa-saml-mock/mujina-sp/target; sudo -u ec2-user nohup java -DSERVICE_HOST=${SERVICE_HOST} -jar laa-saml-mock-sp-1.0.0.jar --spring.config.location=/home/ec2-user/laa-saml-mock/mujina-sp/laa-saml-mock-sp-application.yml &
+cd /home/ec2-user/laa-saml-mock/mujina-sp/target; sudo -u ec2-user nohup java -DIDP_SERVICE_HOST=${IDP_SERVICE_HOST} -DSP_SERVICE_HOST=${SP_SERVICE_HOST} -jar laa-saml-mock-sp-1.0.0.jar --spring.config.location=/home/ec2-user/laa-saml-mock/mujina-sp/laa-saml-mock-sp-application.yml &
 ```
 
 ### 9. Create a service to start with the OS
@@ -140,7 +141,7 @@ sh /home/ec2-user/start-laa-saml-mock-services.sh
 ```
 
 ### 10. Reboot your EC2 instance
-1. The Mock IdP can be contacted at http://${SERVICE_HOST}:8080
+1. The Mock IdP can be contacted at http://${IDP_SERVICE_HOST}:8080
    * e.g. http://35.178.48.233:8080
-2. The Mock SP can be contacted at http://${SERVICE_HOST}:9090
+2. The Mock SP can be contacted at http://${SP_SERVICE_HOST}:9090
    * e.g. http://35.178.48.233:9090

--- a/mujina-idp/Dockerfile
+++ b/mujina-idp/Dockerfile
@@ -1,8 +1,9 @@
 FROM openjdk:8-jdk-alpine
-ENV SERVICE_HOST localhost
+ENV DOCKER_IDP_SERVICE_HOST localhost
+ENV DOCKER_IDP_SERVICE_PORT 8080
 
 VOLUME /tmp
 ADD target/laa-saml-mock-idp-1.0.0.jar app.jar
 COPY docker-idp-application.yml config/idp-application.yml
 
-ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom", "-jar","app.jar", "--spring.config.location=config/idp-application.yml", "-DSERVICE_HOST=${SERVICE_HOST}"]
+ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom", "-jar","app.jar", "--spring.config.location=config/idp-application.yml", "-DIDP_SERVICE_HOST=${DOCKER_IDP_SERVICE_HOST}", "-DIDP_SERVICE_PORT=${DOCKER_IDP_SERVICE_PORT}"]

--- a/mujina-idp/docker-idp-application.yml
+++ b/mujina-idp/docker-idp-application.yml
@@ -1,5 +1,5 @@
 idp:
-  base_url: http://${SERVICE_HOST}:8080
+  base_url: http://${IDP_SERVICE_HOST}:${IDP_SERVICE_PORT}
 
 samlUserStore:
   samlUsers:

--- a/mujina-idp/readme.md
+++ b/mujina-idp/readme.md
@@ -23,10 +23,23 @@ docker build . -t laa-saml-mock-idp
 docker container run -p 8080:8080 laa-saml-mock-idp
 ```
 
-# Run the mock IdP docker container specifying a custom host
-You can use the SERVICE_HOST environment variable to run the mock IdP somewhere other than localhost
+# Run the mock IdP docker container on a custom host
+You can use the DOCKER_IDP_SERVICE_HOST environment variable to run the mock IdP somewhere other than localhost
 ```bash
-docker container run -p 8080:8080 -e SERVICE_HOST=10.98.221.157 laa-saml-mock-idp
+docker container run -p 8080:8080 -e DOCKER_IDP_SERVICE_HOST=10.98.221.157 laa-saml-mock-idp
+```
+
+# Run the mock IdP docker container on a custom port
+You can use the DOCKER_IDP_SERVICE_PORT environment variable to expose the mock IdP from the docker host on a different port than 8080
+```bash
+docker container run -p 8000:8080 -e DOCKER_IDP_SERVICE_PORT=8000 laa-saml-mock-idp
+```
+_the docker host port must match the IDP_SERVICE_PORT port_ e.g. 8000
+
+# Run the mock IdP docker container on a custom host and port
+Use a combination of the DOCKER_IDP_SERVICE_HOST and DOCKER_IDP_SERVICE_PORT environment variables
+```bash
+docker container run -p 8000:8080 -e DOCKER_IDP_SERVICE_HOST=10.98.221.157 -e DOCKER_IDP_SERVICE_PORT=8000 laa-saml-mock-idp
 ```
 
 # Specify an override spring configuration file
@@ -38,5 +51,5 @@ The contents of the file must have the __idp.base_url__ property set to the foll
 SAML IdP application to work correctly
 ```yml
 idp:
-  base_url: http://${SERVICE_HOST}:8080
+  base_url: http://${IDP_SERVICE_HOST}:${IDP_SERVICE_PORT}
 ```


### PR DESCRIPTION
Added new Docker and Spring Boot environment variables for host name
and port:
- IDP_SERVICE_HOST
- IDP_SERVICE_PORT
- DOCKER_IDP_SERVICE_HOST
- DOCKER_IDP_SERVICE_PORT