### PR TITLE
LM-1291: SAML - Mock IdP ECS ephemeral port support

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ vim /home/ec2-user/laa-saml-mock/mujina-idp/laa-saml-mock-idp-application.yml
 ```
 ```
 idp:
-  base_url: http://${SERVICE_HOST}:8080
+  base_url: http://${IDP_SERVICE_HOST}:${IDP_SERVICE_PORT}
 
 samlUserStore:
   samlUsers:
@@ -131,9 +131,10 @@ samlUserStore:
 ##### Start IdP app
 ```
 #!/bin/bash
-export SERVICE_HOST=`curl http://169.254.169.254/latest/meta-data/public-ipv4`;
+export IDP_SERVICE_HOST=`curl http://169.254.169.254/latest/meta-data/public-ipv4`;
+export IDP_SERVICE_PORT=8000;
 
-cd /home/ec2-user/laa-saml-mock/mujina-idp/target; sudo -u ec2-user nohup java -DSERVICE_HOST=${SERVICE_HOST} -jar laa-saml-mock-idp-1.0.0.jar --spring.config.location=/home/ec2-user/laa-saml-mock/mujina-idp/laa-saml-mock-idp-application.yml &
+cd /home/ec2-user/laa-saml-mock/mujina-idp/target; sudo -u ec2-user nohup java -DIDP_SERVICE_HOST=${IDP_SERVICE_HOST} -DIDP_SERVICE_PORT=${IDP_SERVICE_PORT} -jar laa-saml-mock-idp-1.0.0.jar --spring.config.location=/home/ec2-user/laa-saml-mock/mujina-idp/laa-saml-mock-idp-application.yml &
 ```
 
 ##### Tail the log file
@@ -148,19 +149,21 @@ vim /home/ec2-user/laa-saml-mock/mujina-sp/laa-saml-mock-sp-application.yml
 ```
 ```
 sp:
-  base_url: http://${SERVICE_HOST}:9090
+  base_url: http://${SP_SERVICE_HOST}:9090
   entity_id: http://mock-sp
-  idp_metadata_url: http://${SERVICE_HOST}:8080/metadata
-  single_sign_on_service_location: http://${SERVICE_HOST}:8080/SingleSignOnService
+  idp_metadata_url: http://${IDP_SERVICE_HOST}:${IDP_SERVICE_PORT}/metadata
+  single_sign_on_service_location: http://${IDP_SERVICE_HOST}:${IDP_SERVICE_PORT}/SingleSignOnService
   acs_location_path: /saml/SSO
 ```
 
 ##### Start SP app
 ```
 #!/bin/bash
-export SERVICE_HOST=`curl http://169.254.169.254/latest/meta-data/public-ipv4`;
+export IDP_SERVICE_HOST=`curl http://169.254.169.254/latest/meta-data/public-ipv4`;
+export IDP_SERVICE_PORT=8000;
+export SP_SERVICE_HOST=`curl http://169.254.169.254/latest/meta-data/public-ipv4`;
 
-cd /home/ec2-user/laa-saml-mock/mujina-sp/target; sudo -u ec2-user nohup java -DSERVICE_HOST=${SERVICE_HOST} -jar laa-saml-mock-sp-1.0.0.jar --spring.config.location=/home/ec2-user/laa-saml-mock/mujina-sp/laa-saml-mock-sp-application.yml &
+cd /home/ec2-user/laa-saml-mock/mujina-sp/target; sudo -u ec2-user nohup java -DIDP_SERVICE_HOST=${IDP_SERVICE_HOST} -DIDP_SERVICE_PORT=${IDP_SERVICE_PORT} -DSP_SERVICE_HOST=${SP_SERVICE_HOST} -jar laa-saml-mock-sp-1.0.0.jar --spring.config.location=/home/ec2-user/laa-saml-mock/mujina-sp/laa-saml-mock-sp-application.yml &
 ```
 
 ##### Tail the log file

--- a/aws-ec2/readme.md
+++ b/aws-ec2/readme.md
@@ -79,7 +79,7 @@ vim /home/ec2-user/laa-saml-mock/mujina-idp/laa-saml-mock-idp-application.yml
 ... and insert this text:
 ```bash
 idp:
-  base_url: http://${SERVICE_HOST}:8080
+  base_url: http://${IDP_SERVICE_HOST}:${IDP_SERVICE_PORT}
 
 samlUserStore:
   samlUsers:
@@ -97,10 +97,10 @@ vim /home/ec2-user/laa-saml-mock/mujina-sp/laa-saml-mock-sp-application.yml
 ... and insert this text:
 ```bash
 sp:
-  base_url: http://${SERVICE_HOST}:9090
+  base_url: http://${SP_SERVICE_HOST}:9090
   entity_id: http://mock-sp
-  idp_metadata_url: http://${SERVICE_HOST}:8080/metadata
-  single_sign_on_service_location: http://${SERVICE_HOST}:8080/SingleSignOnService
+  idp_metadata_url: http://${IDP_SERVICE_HOST}:${IDP_SERVICE_PORT}/metadata
+  single_sign_on_service_location: http://${IDP_SERVICE_HOST}:${IDP_SERVICE_PORT}/SingleSignOnService
   acs_location_path: /saml/SSO
 ```
 
@@ -112,14 +112,16 @@ vim ~/start-laa-saml-mock-services.sh
 ... and insert this text:
 ```bash
 #!/bin/bash
-export SERVICE_HOST=`curl http://169.254.169.254/latest/meta-data/public-ipv4`;
+export IDP_SERVICE_HOST=`curl http://169.254.169.254/latest/meta-data/public-ipv4`;
+export IDP_SERVICE_PORT=8000;
+export SP_SERVICE_HOST=`curl http://169.254.169.254/latest/meta-data/public-ipv4`;
 
-cd /home/ec2-user/laa-saml-mock/mujina-idp/target; sudo -u ec2-user nohup java -DSERVICE_HOST=${SERVICE_HOST} -jar laa-saml-mock-idp-1.0.0.jar --spring.config.location=/home/ec2-user/laa-saml-mock/mujina-idp/laa-saml-mock-idp-application.yml &
+cd /home/ec2-user/laa-saml-mock/mujina-idp/target; sudo -u ec2-user nohup java -DIDP_SERVICE_HOST=${IDP_SERVICE_HOST} -DIDP_SERVICE_PORT=${IDP_SERVICE_PORT} -jar laa-saml-mock-idp-1.0.0.jar --spring.config.location=/home/ec2-user/laa-saml-mock/mujina-idp/laa-saml-mock-idp-application.yml &
 
 echo "Sleeping for 15 seconds to allow the IdP to start up..."
 sleep 20s
 
-cd /home/ec2-user/laa-saml-mock/mujina-sp/target; sudo -u ec2-user nohup java -DSERVICE_HOST=${SERVICE_HOST} -jar laa-saml-mock-sp-1.0.0.jar --spring.config.location=/home/ec2-user/laa-saml-mock/mujina-sp/laa-saml-mock-sp-application.yml &
+cd /home/ec2-user/laa-saml-mock/mujina-sp/target; sudo -u ec2-user nohup java -DIDP_SERVICE_HOST=${IDP_SERVICE_HOST} -DIDP_SERVICE_PORT=${IDP_SERVICE_PORT} -DSP_SERVICE_HOST=${SP_SERVICE_HOST} -jar laa-saml-mock-sp-1.0.0.jar --spring.config.location=/home/ec2-user/laa-saml-mock/mujina-sp/laa-saml-mock-sp-application.yml &
 ```
 
 ### 9. Create a service to start with the OS
@@ -140,7 +142,7 @@ sh /home/ec2-user/start-laa-saml-mock-services.sh
 ```
 
 ### 10. Reboot your EC2 instance
-1. The Mock IdP can be contacted at http://${SERVICE_HOST}:8080
-   * e.g. http://35.178.48.233:8080
-2. The Mock SP can be contacted at http://${SERVICE_HOST}:9090
+1. The Mock IdP can be contacted at http://${IDP_SERVICE_HOST}:${IDP_SERVICE_PORT}
+   * e.g. http://35.178.48.233:8000
+2. The Mock SP can be contacted at http://${SP_SERVICE_HOST}:9090
    * e.g. http://35.178.48.233:9090

--- a/mujina-idp/Dockerfile
+++ b/mujina-idp/Dockerfile
@@ -1,8 +1,9 @@
 FROM openjdk:8-jdk-alpine
-ENV SERVICE_HOST localhost
+ENV IDP_SERVICE_HOST localhost
+ENV IDP_SERVICE_PORT 8080
 
 VOLUME /tmp
 ADD target/laa-saml-mock-idp-1.0.0.jar app.jar
 COPY docker-idp-application.yml config/idp-application.yml
 
-ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom", "-jar","app.jar", "--spring.config.location=config/idp-application.yml", "-DSERVICE_HOST=${SERVICE_HOST}"]
+ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom", "-jar","app.jar", "--spring.config.location=config/idp-application.yml"]

--- a/mujina-idp/docker-idp-application.yml
+++ b/mujina-idp/docker-idp-application.yml
@@ -1,5 +1,5 @@
 idp:
-  base_url: http://${SERVICE_HOST}:8080
+  base_url: http://${IDP_SERVICE_HOST}:${IDP_SERVICE_PORT}
 
 samlUserStore:
   samlUsers:

--- a/mujina-idp/readme.md
+++ b/mujina-idp/readme.md
@@ -1,7 +1,7 @@
 # Build the mock IdP docker image
 
 ## Prerequisites
-Before building the Docker image, the Spring Boot application artifact must exist in the **target** directory
+Before building the Docker image from the [Dockerfile](Dockerfile), the Spring Boot application artifact must exist in the **target** directory
 
 > e.g. mujina-idp/target/laa-saml-mock-idp-1.0.0.jar
 
@@ -12,31 +12,101 @@ mvn clean install
 cd mujina-idp
 ```
 
-----
-
 ```bash
 docker build . -t laa-saml-mock-idp
 ```
 
+----
+
 # Run the mock IdP docker container
+
+## Run the container on localhost port 8080
 ```bash
 docker container run -p 8080:8080 laa-saml-mock-idp
 ```
 
-# Run the mock IdP docker container specifying a custom host
-You can use the SERVICE_HOST environment variable to run the mock IdP somewhere other than localhost
+## Run the container on a custom host
+You can use the `IDP_SERVICE_HOST` environment variable to run the mock IdP somewhere other than localhost
+
+### Using an IPv4 address:
 ```bash
-docker container run -p 8080:8080 -e SERVICE_HOST=10.98.221.157 laa-saml-mock-idp
+docker container run -p 8080:8080 -e IDP_SERVICE_HOST=10.0.1.10 laa-saml-mock-idp
 ```
 
-# Specify an override spring configuration file
-It is possible to mount a Docker volume to the /config directory and
-provide a file containing a complete override of the spring boot application configuration
+### Using a hostname:
+```bash
+docker container run -p 8080:8080 -e IDP_SERVICE_HOST=dev-saml-mock-idp laa-saml-mock-idp
+```
+
+#### Alternatively, reference an OS environment variable
+```bash
+export IDP_SERVICE_HOST=dev-saml-mock-idp
+...
+docker container run -p $IDP_SERVICE_HOST:8080 -e IDP_SERVICE_HOST=$IDP_SERVICE_HOST laa-saml-mock-idp
+```
+
+## Run the container on a custom port
+You can use the `IDP_SERVICE_PORT` environment variable to expose the mock IdP from the docker host on a different port than 8080
+```bash
+docker container run -p 8000:8080 -e IDP_SERVICE_PORT=8000 laa-saml-mock-idp
+```
+_the docker container host port must match the IDP_SERVICE_PORT port_ e.g. 8000
+
+#### Alternatively, reference an OS environment variable
+```bash
+export IDP_SERVICE_PORT=8000
+...
+docker container run -p $IDP_SERVICE_PORT:8080 -e IDP_SERVICE_PORT=$IDP_SERVICE_PORT laa-saml-mock-idp
+```
+
+## Run the container on a custom host and port
+Use a combination of the `IDP_SERVICE_HOST` and `IDP_SERVICE_PORT` environment variables
+```bash
+docker container run -p 8000:8080 -e IDP_SERVICE_HOST=10.0.1.10 -e IDP_SERVICE_PORT=8000 laa-saml-mock-idp
+```
+
+# Specify an override Spring Boot configuration file
+It is possible to mount a Docker volume to the /config directory and supply
+a file containing an override of the spring boot application
+configuration, __including user data__:
 - e.g. config/idp-application.yml
 
-The contents of the file must have the __idp.base_url__ property set to the following value in order for the
-SAML IdP application to work correctly
+The contents of the file must have at least a __idp.base_url__ property
+using the expected environment variables if you want to run it outside
+of localhost:8080
+- IDP_SERVICE_HOST
+- IDP_SERVICE_PORT
+
 ```yml
 idp:
-  base_url: http://${SERVICE_HOST}:8080
+  base_url: http://${IDP_SERVICE_HOST}:${IDP_SERVICE_PORT}
+
+samlUserStore:
+    samlUsers:
+      - username: test-user
+        password: test password
+        samlAttributes:
+          attribute 1: test attribute 1 value
+          attribute 2: test attribute 2 value
+```
+
+These values can be passed to the docker container as environment variables (_-e flag_).
+```bash
+docker container run -p 8000:8080 -e IDP_SERVICE_HOST=10.0.1.10 -e IDP_SERVICE_PORT=8000 -v /${PWD}/config:/config laa-saml-mock-idp
+```
+
+Or a hardcoded base_url value can be used:
+```yml
+idp:
+  base_url: http://dev-saml-mock-idp:8000
+```
+
+If not specified, the containers default environment variable values will be used
+- IDP_SERVICE_HOST: _localhost_
+- IDP_SERVICE_PORT: _8080_
+
+Resulting in...
+```yml
+idp:
+  base_url: http://localhost:8080
 ```


### PR DESCRIPTION
Added new Docker and Spring Boot environment variables for host name
and port to support ECS emphemeral port range:
-- IDP_SERVICE_HOST
-- IDP_SERVICE_PORT
-- DOCKER_IDP_SERVICE_HOST
-- DOCKER_IDP_SERVICE_PORT

- Removing -D environment variables in docker ENTRYPOINT
- Using IDP_SERVICE_HOST/IDP_SERVICE_PORT variable names