### PR TITLE
Add OWASP dependency check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,21 @@
           <autoVersionSubmodules>true</autoVersionSubmodules>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.owasp</groupId>
+        <artifactId>dependency-check-maven</artifactId>
+        <version>3.1.1</version>
+        <configuration>
+          <failBuildOnCVSS>8</failBuildOnCVSS>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
     <extensions>
       <extension>
@@ -118,6 +133,22 @@
       </extension>
     </extensions>
   </build>
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.owasp</groupId>
+        <artifactId>dependency-check-maven</artifactId>
+        <version>3.1.1</version>
+        <reportSets>
+          <reportSet>
+            <reports>
+              <report>aggregate</report>
+            </reports>
+         </reportSet>
+        </reportSets>
+      </plugin>
+    </plugins>
+  </reporting>
   <distributionManagement>
     <repository>
       <id>openconext-releases</id>


### PR DESCRIPTION
We would like to know whether a service we're running has any security
holes.

`mvn install site` will generate a report that shows whether there are
things that we should address.

Alternatively, `mvn verify` will generate an individual report for each
module, but they're harder to navigate.