### PR TITLE
LM-1435 OWASP Dependancy Check added

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,21 @@
           <autoVersionSubmodules>true</autoVersionSubmodules>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.owasp</groupId>
+        <artifactId>dependency-check-maven</artifactId>
+        <version>3.1.1</version>
+        <configuration>
+          <failBuildOnCVSS>8</failBuildOnCVSS>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
     <extensions>
       <extension>


### PR DESCRIPTION
Team 6 requested this added as we will be exposing the Mock IDP
externally. Initial fail level set to 8 to ensure build passes.
Identified vulnerabilities will now be reviewed.

We would like to know whether a service we're running has any security
holes.

`mvn install site` will generate a report that shows whether there are things that we should address.