### PR TITLE
LM-1444 updates to fix dependancy check CVEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ target/
 .project
 .settings
 application.t03.yml
+.DS_Store

--- a/mujina-common/pom.xml
+++ b/mujina-common/pom.xml
@@ -57,5 +57,10 @@
       <artifactId>spring-boot-starter-actuator</artifactId>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>xalan</groupId>
+      <artifactId>xalan</artifactId>
+      <version>${xalan.version}</version>
+    </dependency>
   </dependencies>
 </project>

--- a/mujina-idp/pom.xml
+++ b/mujina-idp/pom.xml
@@ -70,6 +70,11 @@
       <version>3.0.2</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>xalan</groupId>
+      <artifactId>xalan</artifactId>
+      <version>${xalan.version}</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -25,16 +25,17 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.8</java.version>
-    <spring-boot.version>1.5.2.RELEASE</spring-boot.version>
     <spring-security-oauth2.version>2.1.0.RELEASE</spring-security-oauth2.version>
     <httpclient.version>4.5.3</httpclient.version>
     <spring-security-saml2-core.version>1.0.2.RELEASE</spring-security-saml2-core.version>
+    <jackson.version>2.9.4</jackson.version>
+    <xalan.version>2.7.2</xalan.version>
   </properties>
 
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>1.5.2.RELEASE</version>
+    <version>1.5.9.RELEASE</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
The following were fixed:
CVE-2014-0107,CVE-2017-5651,CVE-2017-15095,CVE-2017-17485,CVE-2017-7525
Dependancies were upgraded as far as possible without breaking the build or requiring addition dev work.  The following High CVEs remain but are not relevant to us:
CVE-2016-5425, CVE-2016-6325, CVE-2012-0881

(Couldn't use the ${spring-boot.version} property within the parent tags.)

Also added .DS_Store to the git ignore for the sanity of Mac users.