### PR TITLE
Fixed CA Cert issue in codebuild

### DIFF
--- a/buildspec-lz.yml
+++ b/buildspec-lz.yml
@@ -7,6 +7,7 @@ phases:
       - add-apt-repository ppa:openjdk-r/ppa
       - apt-get update -y
       - apt-get install -y openjdk-8-jdk
+      - update-ca-certificates -f
       - echo Installing maven...
       - wget http://apache.mirror.anlx.net/maven/maven-3/3.5.2/binaries/apache-maven-3.5.2-bin.tar.gz
       - tar -zxvf apache-maven-3.5.2-bin.tar.gz

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -11,6 +11,7 @@ phases:
       - add-apt-repository ppa:openjdk-r/ppa
       - apt-get update -y
       - apt-get install -y openjdk-8-jdk
+      - update-ca-certificates -f
       - echo Installing maven...
       - wget http://apache.mirror.anlx.net/maven/maven-3/3.5.2/binaries/apache-maven-3.5.2-bin.tar.gz
       - tar -zxvf apache-maven-3.5.2-bin.tar.gz


### PR DESCRIPTION
java.security.InvalidAlgorithmParameterException: the trustAnchors
parameter must be non-empty started appearing in codebuild maven builds.
This was due to the Java CA certs not being configured properly.