### PR TITLE
LM 1097 enable ssl in mock IDP

### DIFF
--- a/mujina-idp/src/main/java/mujina/idp/TomcatRedirectHttpToHttpsConfig.java
+++ b/mujina-idp/src/main/java/mujina/idp/TomcatRedirectHttpToHttpsConfig.java
@@ -1,0 +1,15 @@
+package mujina.idp;
+
+import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.apache.catalina.valves.rewrite.RewriteValve;
+
+@Configuration
+public class TomcatRedirectHttpToHttpsConfig {
+  @Bean TomcatEmbeddedServletContainerFactory servletContainerFactory() {
+    TomcatEmbeddedServletContainerFactory factory = new TomcatEmbeddedServletContainerFactory();
+    factory.addContextValves(new RewriteValve());
+    return factory;
+  }
+}

--- a/mujina-idp/src/main/resources/WEB-INF/rewrite.conf
+++ b/mujina-idp/src/main/resources/WEB-INF/rewrite.conf
@@ -1,0 +1,3 @@
+RewriteCond %{HTTP:X-Forwarded-Proto} !https
+RewriteCond %{HTTPS} off
+RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301,NE]

--- a/mujina-idp/src/main/resources/application.yml
+++ b/mujina-idp/src/main/resources/application.yml
@@ -12,6 +12,10 @@ server:
     timeout: 28800
     cookie:
       secure: false
+  #SSL info forwarding
+  tomcat:
+    remote_ip_header: x-forwarded-for
+    protocol_header: x-forwarded-proto
 
 # Identity Provider
 idp:


### PR DESCRIPTION
Currently when behind a load balancer, the app server is redirecting to non ssl, this will redirect to https if the request comes in as https.  This was needed as the mock IDP needs to be exposed externally.