### PR TITLE
Add OneLogin Java SAML toolkit properties file link

### DIFF
--- a/onelogin/onelogin.saml.properties
+++ b/onelogin/onelogin.saml.properties
@@ -1,3 +1,6 @@
+# Original source of properties https://github.com/onelogin/java-saml/blob/master/samples/java-saml-tookit-jspsample/src/main/resources/onelogin.saml.properties
+# =============================
+
 onelogin.saml2.strict = true
 onelogin.saml2.debug =  false
 


### PR DESCRIPTION
Added a link to the original properties file in the OneLogin Java SAML toolkit
github repository.