### PR TITLE
Maven broke the build.

### DIFF
--- a/buildspec-lz.yml
+++ b/buildspec-lz.yml
@@ -1,7 +1,7 @@
 version: 0.2
 env:
   variables:
-    MAVEN_VERSION: "3.5.3"
+    MAVEN_VERSION: "3.5.4"
 phases:
   install:
     commands:


### PR DESCRIPTION
Maven have updated the version of their software, which also removed the previous version,
thereby killing the build of SAML.

the Buildspec now has the current version set, which will allow the build to work again.
HAZAAR!