### PR TITLE
TA-578 Fix saml mock IDP pipeline build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
 cache:
   directories:
     - $HOME/.m2

--- a/mujina-common/pom.xml
+++ b/mujina-common/pom.xml
@@ -38,6 +38,11 @@
       <version>2.5</version>
     </dependency>
     <dependency>
+      <groupId>org.opensaml</groupId>
+      <artifactId>openws</artifactId>
+      <version>${openws.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.security.extensions</groupId>
       <artifactId>spring-security-saml2-core</artifactId>
       <version>${spring-security-saml2-core.version}</version>

--- a/mujina-common/pom.xml
+++ b/mujina-common/pom.xml
@@ -57,10 +57,5 @@
       <artifactId>spring-boot-starter-actuator</artifactId>
       <scope>compile</scope>
     </dependency>
-    <dependency>
-      <groupId>xalan</groupId>
-      <artifactId>xalan</artifactId>
-      <version>${xalan.version}</version>
-    </dependency>
   </dependencies>
 </project>

--- a/mujina-idp/pom.xml
+++ b/mujina-idp/pom.xml
@@ -70,11 +70,6 @@
       <version>3.0.2</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>xalan</groupId>
-      <artifactId>xalan</artifactId>
-      <version>${xalan.version}</version>
-    </dependency>
   </dependencies>
 
   <build>

--- a/owasp-suppressions.xml
+++ b/owasp-suppressions.xml
@@ -12,4 +12,33 @@
       <cpe>cpe/:a:bouncycastle:legion-of-the-bouncy-castle-java-crytography-api</cpe>
       <cve>CVE-2018-1000613</cve>
    </suppress>
+   <suppress>
+      <notes><![CDATA[
+      This suppresses CVE-2018-1258 which is necessary because of a bug in the owasp dependency-check-maven plugin
+      Open issue: https://github.com/jeremylong/DependencyCheck/issues/1827#issuecomment-485010406
+      According to https://pivotal.io/security/cve-2018-1258:
+      "Users leveraging Spring Framework 4.x (Spring Security 4.x or Spring Boot 1.x) are not impacted so no steps are necessary.|
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.springframework\.security/spring-security-(core|web|config)@4.*$</packageUrl>
+      <cpe>cpe/:a:pivotal_software:spring_security</cpe>
+      <cve>CVE-2018-1258</cve>
+   </suppress>
+   <suppress>
+      <notes><![CDATA[
+      This suppresses CVE-2017-8046 as it doesn't impact the current version of Spring Boot in the mujina-common package below.
+      According to https://nvd.nist.gov/vuln/detail/CVE-2017-8046 it affects Spring Boot versions prior to 1.5.9 only.
+      ]]></notes>
+      <packageUrl>pkg:maven/uk.gov.justice.legalaid/mujina-common@1.0.0</packageUrl>
+      <cpe>cpe/:a:pivotal_software:spring_framework</cpe>
+      <cve>CVE-2017-8046</cve>
+   </suppress>
+   <suppress>
+      <notes><![CDATA[
+      This suppresses CVE-2018-1270 as it doesn't impact the current version of Spring Framework in the mujina-common package below.
+      According to https://nvd.nist.gov/vuln/detail/CVE-2018-1270 it affects Spring Framework, versions 5.0 prior to 5.0.5 and versions 4.3 prior to 4.3.15
+      ]]></notes>
+      <packageUrl>pkg:maven/uk.gov.justice.legalaid/mujina-common@1.0.0</packageUrl>
+      <cpe>cpe/:a:pivotal_software:spring_framework</cpe>
+      <cve>CVE-2018-1270</cve>
+   </suppress>
 </suppressions>

--- a/owasp-suppressions.xml
+++ b/owasp-suppressions.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+   <suppress>
+      <notes><![CDATA[
+      Suppresses CVE-2018-1258, detected as a false positive with the current version of the package below (1.51).
+      The problem does not impact versions of this implementation for the algorithm prior to version 1.57.
+      Quoting https://access.redhat.com/security/cve/cve-2018-1000613:
+      "The XMSS/XMSS^MT algorithms were first introduced in upstream bouncycastle version 1.57.
+      Versions prior to this, that have not had the new algorithms back-ported, are not affected."
+      ]]></notes>
+      <packageUrl>pkg:maven/org.bouncycastle/bcprov-jdk15on@1.51</packageUrl>
+      <cpe>cpe/:a:bouncycastle:legion-of-the-bouncy-castle-java-crytography-api</cpe>
+      <cve>CVE-2018-1000613</cve>
+   </suppress>
+</suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,8 @@
     <httpclient.version>4.5.3</httpclient.version>
     <spring-security-saml2-core.version>1.0.2.RELEASE</spring-security-saml2-core.version>
     <spring.version>4.3.16.RELEASE</spring.version>
-    <jackson.version>2.9.4</jackson.version>
     <xalan.version>2.7.2</xalan.version>
+    <jackson.version>2.10.2</jackson.version>
   </properties>
 
   <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,6 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.8</java.version>
-    <spring-security-oauth2.version>2.1.0.RELEASE</spring-security-oauth2.version>
     <httpclient.version>4.5.3</httpclient.version>
     <spring-security-saml2-core.version>1.0.2.RELEASE</spring-security-saml2-core.version>
     <spring.version>4.3.16.RELEASE</spring.version>

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
     <spring.version>4.3.16.RELEASE</spring.version>
     <jackson.version>2.10.2</jackson.version>
     <openws.version>1.5.4</openws.version>
+    <tomcat.version>8.5.50</tomcat.version>
   </properties>
 
   <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,7 @@
         <version>5.3.0</version>
         <configuration>
           <failBuildOnCVSS>8</failBuildOnCVSS>
+          <suppressionFile>${project.basedir}/../owasp-suppressions.xml</suppressionFile>
         </configuration>
         <executions>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,6 @@
     <httpclient.version>4.5.3</httpclient.version>
     <spring-security-saml2-core.version>1.0.2.RELEASE</spring-security-saml2-core.version>
     <spring.version>4.3.16.RELEASE</spring.version>
-    <xalan.version>2.7.2</xalan.version>
     <jackson.version>2.10.2</jackson.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
     <spring-security-saml2-core.version>1.0.2.RELEASE</spring-security-saml2-core.version>
     <spring.version>4.3.16.RELEASE</spring.version>
     <jackson.version>2.10.2</jackson.version>
+    <openws.version>1.5.4</openws.version>
   </properties>
 
   <parent>
@@ -116,7 +117,7 @@
         <version>5.3.0</version>
         <configuration>
           <failBuildOnCVSS>8</failBuildOnCVSS>
-          <suppressionFile>${project.basedir}/../owasp-suppressions.xml</suppressionFile>
+          <suppressionFile>owasp-suppressions.xml</suppressionFile>
         </configuration>
         <executions>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
     <spring-security-oauth2.version>2.1.0.RELEASE</spring-security-oauth2.version>
     <httpclient.version>4.5.3</httpclient.version>
     <spring-security-saml2-core.version>1.0.2.RELEASE</spring-security-saml2-core.version>
+    <spring.version>4.3.16.RELEASE</spring.version>
     <jackson.version>2.9.4</jackson.version>
     <xalan.version>2.7.2</xalan.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
       <plugin>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-maven</artifactId>
-        <version>3.1.1</version>
+        <version>5.3.0</version>
         <configuration>
           <failBuildOnCVSS>8</failBuildOnCVSS>
         </configuration>


### PR DESCRIPTION
This PR fixes a broken build because of some CVEs detected by the `dependency-check-maven` plugin. These are listed in the commits.

Please note that the above plugin had to be bumped to the latest version in order to work, and some CVEs had to be suppressed manually because of a bug in the actual plugin (the engine is not capable of applying AND conditions properly, please check open issue in related commit in the history).

Minimum patch/minor version bumps applied in order to avoid code changes. Tested locally.

https://dsdmoj.atlassian.net/browse/TA-578