### PR TITLE
Bump tomcat to address CVE 2020-1938

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <spring.version>4.3.16.RELEASE</spring.version>
     <jackson.version>2.10.2</jackson.version>
     <openws.version>1.5.4</openws.version>
-    <tomcat.version>8.5.50</tomcat.version>
+    <tomcat.version>8.5.51</tomcat.version>
   </properties>
 
   <parent>


### PR DESCRIPTION
As per title, this addresses CVE-2020-1938 and fixes a broken build in AWS.
